### PR TITLE
Clean up only created device or directories by the process

### DIFF
--- a/device.go
+++ b/device.go
@@ -63,15 +63,11 @@ func OpenTCMUDevice(devPath string, scsi *SCSIHandler) (*Device, error) {
 		uioFd:   -1,
 		hbaDir:  fmt.Sprintf(configDirFmt, scsi.HBA),
 	}
-	err := d.Close()
-	if err != nil {
-		return nil, err
-	}
 	if err := d.preEnableTcmu(); err != nil {
-		return nil, err
+		return d, err
 	}
 	if err := d.start(); err != nil {
-		return nil, err
+		return d, err
 	}
 
 	return d, d.postEnableTcmu()
@@ -340,7 +336,7 @@ func (d *Device) teardown() error {
 	for _, p := range pathsToRemove {
 		err := remove(p)
 		if err != nil {
-			return err
+			logrus.Errorf("Failed to remove: %v", err)
 		}
 	}
 


### PR DESCRIPTION
device: clean up only created device or directories by the process

This patches introduces a map to hold devices or directories which created by the process
for cleaning up them when Close is called.

Fixes https://github.com/coreos/go-tcmu/issues/7