### PR TITLE
fix logrus import collision

### DIFF
--- a/cmd/tcmufile/tcmufile.go
+++ b/cmd/tcmufile/tcmufile.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/coreos/go-tcmu"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -42,7 +42,6 @@ func main() {
 		}
 	}()
 	<-mainClose
-
 }
 
 func die(why string, args ...interface{}) {

--- a/device.go
+++ b/device.go
@@ -15,8 +15,8 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/prometheus/common/log"
+	"github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
package: fix case-insensitive import collision

Since sirupsen/logrus changed lower-case for their project name,
go-tcmu fails to run due to case-insensitive import collision. This
patch changes the package name to lower case.

ref: https://github.com/sirupsen/logrus/issues/543#issuecomment-306586409