### PR TITLE
device: Disable netlink support for the device used by go-tcmu

### DIFF
--- a/device.go
+++ b/device.go
@@ -93,6 +93,7 @@ func (d *Device) preEnableTcmu() error {
 		fmt.Sprintf("dev_size=%d", d.scsi.DataSizes.VolumeSize),
 		fmt.Sprintf("dev_config=%s", d.GetDevConfig()),
 		fmt.Sprintf("hw_block_size=%d", d.scsi.DataSizes.BlockSize),
+		"nl_reply_supported=-1",
 		"async=1",
 	})
 	if err != nil {


### PR DESCRIPTION
device: Disable netlink support for the device used by go-tcmu

This patch disables netlink support by adding
`nl_reply_supported=-1`. This makes go-tcmu program possible to run
with other netlink supported program which also uses
target_core_user.ko on the same host.

If some program enabled netlink support on target_core_user.ko,
go-tcmu stops working as it does not implement netlink device event
handling.

Although go-tcmu could implement netlink support, go-tcmu is a
non-daemon process (so not necessary the device event handling) and
kernel upstream kindly accepted to support the option to disabe
netlink support *1.

*1 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v4.15-rc1&id=b849b4567549d5a54ab34ffacfd48fca05e8b34e

Fixes https://github.com/coreos/go-tcmu/issues/15